### PR TITLE
Enable the chat bot in dm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,21 @@
 {
-  "python.formatting.provider": "black"
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    },
+  },
+  "python.formatting.provider": "none",
+  "isort.args": [
+    "--profile",
+    "black"
+  ],
+  "python.linting.flake8Enabled": true,
+  "python.linting.lintOnSave": true,
+  "python.linting.pylintEnabled": false,
+  "python.linting.flake8Args": [
+    "--ignore",
+    "E501"
+  ],
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # gpt-slack-bot
 
+## Slack
+
+1. Create an Slack app
+
+    - See [the document](https://slack.dev/bolt-python/tutorial/getting-started).
+
+1. Socket Mode
+
+    - On
+
+1. Bot Token Scopes
+
+    - app_mentions:read
+    - chat:write
+
+1. App Token Scopes
+
+    - connections:write
+
 ## Usage
 
 ### Prerequisites
@@ -36,3 +55,8 @@
     ```shell
     python app.py
     ```
+
+## References
+
+- [Slack | Bolt for Python](https://slack.dev/bolt-python/concepts)
+- [GitHub - openai/openai-python: The OpenAI Python library provides convenient access to the OpenAI API from applications written in the Python language.](https://github.com/openai/openai-python)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 
     - connections:write
 
+1. Event Subscriptions (Subscribe to bot events)
+
+    - app_mentions:read
+
 ## Usage
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
 
     - app_mentions:read
 
+1. Messages Tab
+
+    - App Home --> Show Tabs --> Messages Tab
+    - Check `Allow users to send Slash commands and messages from the messages tab`
+
 ## Usage
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # gpt-slack-bot
 
-## Slack
+You can talk to the chat bot using OpenAI Chat API via Slack.
+
+## Features
+
+### Public and private channels in which the bot is added
+
+You have to mention the bot to talk to it.
+
+### Direct messages to the bot
+
+You can talk to the bot without mentioning it.
+
+## Slack App Configuration
 
 1. Create an Slack app
 
@@ -14,6 +26,9 @@
 
     - app_mentions:read
     - chat:write
+    - im:history
+    - im:read
+    - im:write
 
 1. App Token Scopes
 
@@ -22,6 +37,7 @@
 1. Event Subscriptions (Subscribe to bot events)
 
     - app_mentions:read
+    - message.im
 
 1. Messages Tab
 

--- a/constant.py
+++ b/constant.py
@@ -1,0 +1,19 @@
+import os
+
+import openai
+from slack_sdk import WebClient
+
+# MODEL_NAME = "gpt-3.5-turbo"
+# MODEL_MAX_TOKEN_LENGTH = 4097
+MODEL_NAME = "gpt-4"
+MODEL_MAX_TOKEN_LENGTH = 8192
+
+SYSTEM_PROMPT = f"""
+あなたは OpenAI API の {MODEL_NAME} モデルを利用した Slack Bot です。
+"""
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+slack_bot_token = os.getenv("SLACK_BOT_TOKEN")
+slack_app_token = os.getenv("SLACK_APP_TOKEN")
+
+bot_id = WebClient(token=slack_bot_token).auth_test()["user_id"]

--- a/simple_qa.py
+++ b/simple_qa.py
@@ -1,0 +1,71 @@
+import openai
+import tiktoken
+
+from constant import MODEL_MAX_TOKEN_LENGTH, MODEL_NAME, SYSTEM_PROMPT, bot_id
+from database import Message
+
+
+def generate_answer(messages):
+    enc = tiktoken.encoding_for_model(MODEL_NAME)
+    input = [{"role": "system", "content": SYSTEM_PROMPT}]
+    total_token_length = len(enc.encode(SYSTEM_PROMPT))
+    for message in reversed(messages):
+        token_length = len(enc.encode(message.content))
+        # なぜかOpenAIサーバー側のトークンカウントと微妙に一致しないため、係数 0.9 を使う
+        if total_token_length + token_length > MODEL_MAX_TOKEN_LENGTH * 0.9:
+            break
+        input.insert(1, {"role": message.role, "content": message.content})
+        total_token_length += token_length
+    try:
+        completion = openai.ChatCompletion.create(model=MODEL_NAME, messages=input)
+        return completion.choices[0].message["content"]
+    except openai.error.InvalidRequestError as e:
+        return "OpenAI API に対する無効なリクエストです。\nエラー詳細: " + str(e)
+    except openai.error.APIError as e:
+        return "OpenAI API サーバーが API エラーを返しました。時間を置いて再度お試しください。\nエラー詳細: " + str(e)
+    except openai.error.RateLimitError as e:
+        return "OpenAI API サーバーがレート制限エラーを返しました。\nエラー詳細: " + str(e)
+    except Exception as e:
+        return "OpenAI API サーバーがエラーを返しました。\nエラー詳細: " + str(e)
+
+
+def say_answer(event, say, session):
+    channel_id = event["channel"]
+    thread_ts = event.get("thread_ts", event["ts"])
+    user_id = event["user"]
+    content = event["text"]
+    # mentioned_users = re.findall(r"<@([A-Z0-9]+)>", content)
+
+    user_message = Message(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        role="user",
+        sender=user_id,
+        # TODO: 複数ユーザーにメンションされた場合の処理は未検討
+        # receiver=mentioned_users[0],
+        receiver=bot_id,
+        content=content,
+    )
+    session.add(user_message)
+    session.commit()
+
+    messages = (
+        session.query(Message)
+        .filter(Message.thread_ts == thread_ts)
+        .order_by(Message.id)
+        .all()
+    )
+
+    answer = generate_answer(messages)
+    say(text=answer, thread_ts=thread_ts)
+
+    assistant_message = Message(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        role="assistant",
+        sender=bot_id,
+        receiver=user_id,
+        content=answer,
+    )
+    session.add(assistant_message)
+    session.commit()


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Added configuration settings to enable automatic formatting and linting for Python code using `black` and `flake8`. Also added constants for a Slack bot using OpenAI's GPT-4 model and initialized the OpenAI API key and Slack tokens.
- Needs Review: Modified logic and functionality of the code to enable the chat bot in direct messages by adding a new function `generate_answer` and modifying the existing function `say_answer` to use it. Also added documentation on how to configure and use the chat bot via Slack.

> "Code quality improved, bugs removed,
> Chat bot now DMs with attitude.
> With `black` and `flake8`, code is neat,
> And docs are clear, instructions complete."
<!-- end of auto-generated comment: release notes by openai -->