### PR TITLE
Add option to enale saving messages to sqlite

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.app.async_app import AsyncApp
 
 import simple_qa
-from constant import slack_app_token, slack_bot_token
+from configuration import slack_app_token, slack_bot_token
 from database import create_session
 
 app = AsyncApp(token=slack_bot_token)

--- a/configuration.py
+++ b/configuration.py
@@ -3,6 +3,8 @@ import os
 import openai
 from slack_sdk import WebClient
 
+IS_MESSAGE_SAVE_ENABLED = False  # Save messages to sqlite database
+
 # MODEL_NAME = "gpt-3.5-turbo"
 # MODEL_MAX_TOKEN_LENGTH = 4097
 
@@ -12,10 +14,14 @@ MODEL_MAX_TOKEN_LENGTH = 8192
 
 SYSTEM_PROMPT = f"""
 あなたは OpenAI API の {MODEL_NAME} モデルを利用した Slack Bot です。
+これから行われる一連の会話は、Slack スレッド上で行われるものです。
+過去のスレッドメッセージも含めて、OpenAI API に送信されます。
 """
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 slack_bot_token = os.getenv("SLACK_BOT_TOKEN")
 slack_app_token = os.getenv("SLACK_APP_TOKEN")
 
-bot_id = WebClient(token=slack_bot_token).auth_test()["user_id"]
+
+slack_client = WebClient(token=slack_bot_token)
+bot_id = slack_client.auth_test()["user_id"]

--- a/models/message.py
+++ b/models/message.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Message:
+    channel_id: str
+    thread_ts: str
+    role: str
+    sender: str
+    receiver: str
+    content: str
+    timestamp: str


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a configuration option `IS_MESSAGE_SAVE_ENABLED` to control whether messages should be saved to a SQLite database.
- Refactor: Updated the import statement for Slack tokens and introduced a new `slack_client` object for better interaction with the Slack API.
- New Feature: Added a function `get_thread_messages` in `simple_qa.py` to retrieve messages from the Slack API.
- Refactor: Split the logic for generating and saying answers into two separate functions `say_answer_with_sqlite` and `say_answer_without_sqlite` based on the value of `IS_MESSAGE_SAVE_ENABLED`.
- New Feature: Added a new data class `Message` in `models/message.py` to represent different properties of a message.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->